### PR TITLE
Disable SIP using Recovery OS

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -463,10 +463,6 @@
 			<dict>
 				<key>boot-args</key>
 				<string>alcid=11 shikigva=32 shiki-id=Mac-BE088AF8C5EB4FA2 -disablegfxfirmware brcmfx-country=#a</string>
-				<key>csr-active-config</key>
-				<data>
-				AAAAAA==
-				</data>
 			</dict>
 		</dict>
 	</dict>


### PR DESCRIPTION
Fixes #78 by not hard coding a default `csr-active-config` value. Because SIP defaults to on, it should be safe to not force the value using `Add` in config.plist. Without a default value, OSX will read it from the NVRAM which can be modified in Recovery OS.