### PR TITLE
config: fix USB port identification as external

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -193,6 +193,20 @@
 				WEUyMA==
 				</data>
 			</dict>
+			<dict>
+				<key>Comment</key>
+				<string>patch XHC.RHUB.GUPC to show ports as external</string>
+				<key>Enabled</key>
+				<true/>
+				<key>Find</key>
+				<data>
+				R1VQQwkIUENLRxIHBAAK/w==
+				</data>
+				<key>Replace</key>
+				<data>
+				R1VQQwkIUENLRxIHBAAKAw==
+				</data>
+			</dict>
 		</array>
 	</dict>
 	<key>Booter</key>


### PR DESCRIPTION
The default _UPC() returned by GUPC() is 0xFF (internal USB) for the
connector type. We patch the ACPI to return 0x03 (USB 3 A) instead.

Fixes #148

Please test @KrisCris