### PR TITLE
TB3: fix XDomain and lane speed issue

### DIFF
--- a/OC/config.plist
+++ b/OC/config.plist
@@ -261,6 +261,20 @@
 				<key>name</key>
 				<string>pci8086,a102</string>
 			</dict>
+			<key>PciRoot(0x0)/Pci(0x1c,0x4)/Pci(0x0,0x0)/Pci(0x0,0x0)/Pci(0x0,0x0)</key>
+			<dict>
+				<key>ThunderboltDROM</key>
+				<data>
+				mgAAAAAAAIaAGnNQgwFkAIaAcyABIQiBgAKAAAAACIKQ
+				AYAAAAAIg4AEgAEAAAiEkAOAAQAAAoULhiABAGQAAAAA
+				AAOHgAWIUAAABYlQAAAFilAAAAWLUAAACAFJbnRlbAAP
+				AkhhZGVzIENhbnlvbgA=
+				</data>
+				<key>linkDetails</key>
+				<data>
+				CAAAAAMAAAA=
+				</data>
+			</dict>
 			<key>PciRoot(0x0)/Pci(0x1c,0x4)/Pci(0x0,0x0)/Pci(0x2,0x0)/Pci(0x0,0x0)</key>
 			<dict>
 				<key>built-in</key>

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -215,11 +215,11 @@
 		<dict>
 			<key>AvoidRuntimeDefrag</key>
 			<true/>
+			<key>DevirtualiseMmio</key>
+			<true/>
 			<key>EnableWriteUnprotector</key>
 			<true/>
 			<key>ProvideCustomSlide</key>
-			<true/>
-			<key>DevirtualiseMmio</key>
 			<true/>
 		</dict>
 	</dict>


### PR DESCRIPTION
Add linkDetails to identify dual-lane support (fixes #149)
Add ThunderboltDROM to fix XDomain support (fixes #147)

AppleThunderboltIP was not working due to a bug where if the NHI "port"
was marked "disabled" by the DROM, then a field returns 0 and underflows.
The fix is to replace the DROM with a patched version that does not have
the NHI port (port 5) disabled. The CRC32 is also updated.

Alternatively, we could use TBPatcher to permanently change DROM but it's
too complex to manage the case of updating patches (and supporting patch
uninstallation).
Unified Split
