### PR TITLE
config: fixed boot issue with multiple EC

### DIFF
--- a/ACPI/SSDT-Xhci.asl
+++ b/ACPI/SSDT-Xhci.asl
@@ -307,6 +307,11 @@ DefinitionBlock ("", "SSDT", 2, "OSY86 ", "Xhci", 0x00001000)
             }
         }
 
+        Device(\_SB.EC) // fake EC for AppleBusPowerController matching
+        {
+            Name(_HID, "EC000000")  // _HID: Hardware ID
+        }
+
         Device (\_SB.USBW)
         {
             Name (_HID, "PNP0D10")  // _HID: Hardware ID

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -137,16 +137,16 @@
 			</dict>
 			<dict>
 				<key>Comment</key>
-				<string>change H_EC to EC for USB power</string>
+				<string>patch PNP0C09 to PNPFFFF for boot issue workaround</string>
 				<key>Enabled</key>
 				<true/>
 				<key>Find</key>
 				<data>
-				SF9FQw==
+				QdAMCQ==
 				</data>
 				<key>Replace</key>
 				<data>
-				RUNfXw==
+				QdD//w==
 				</data>
 			</dict>
 			<dict>


### PR DESCRIPTION
On some machines an extra embedded controller device (PNP0C09) named ECDV
is present and causes boot to fail on 10.15. This patch disables both H_EC
and ECDV by replacing PNP0C09 with PNPFFFF. Because a device named "EC"
must exist for AppleBusPowerController matching, we create a fake device
named EC in addition to the other two.

The NUC does not have a real embedded controller so matching the EC driver
to H_EC or ECDV was bad anyways. Our new fake EC will not load the driver.

Fixes #169