### PR TITLE
[WIP] Update OpenCore to 0.5.6

### DIFF
--- a/Installer/data/AirportBrcmFixup/source.txt
+++ b/Installer/data/AirportBrcmFixup/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/AirportBrcmFixup/releases/download/2.0.5/AirportBrcmFixup-2.0.5-RELEASE.zip
-9d104e7f3e034fa89f9ee8741bd9c3747584035dd636a9e9c7bde3bf7fcd988a
+https://github.com/acidanthera/AirportBrcmFixup/releases/download/2.0.6/AirportBrcmFixup-2.0.6-RELEASE.zip
+7be879f491e7fe3aec75cb276a8ceddfb72ce50c95420ac8a5d133e8e878af02

--- a/Installer/data/AppleALC/source.txt
+++ b/Installer/data/AppleALC/source.txt
@@ -1,2 +1,2 @@
-https://github.com/osy86/AppleALC/releases/download/1.4.6/AppleALC-1.4.6-RELEASE.zip
-36dcaf1195da0a2993889b7ac8dd02307c143631ff2c83276946ec71f5938b03
+https://github.com/acidanthera/AppleALC/releases/download/1.4.7/AppleALC-1.4.7-RELEASE.zip
+31b4d42f3d42726141d7b6d6eed04dd140713bd0a905f0f61bf7b2f97f6e76d7

--- a/Installer/data/AppleSupport/source.txt
+++ b/Installer/data/AppleSupport/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/AppleSupportPkg/releases/download/2.1.5/AppleSupport-2.1.5-RELEASE.zip
-22e7bd632473f86bbaab272c08e5b544b50a6e2a95cb81883e2c1b7c18fb87ff
+https://github.com/acidanthera/AppleSupportPkg/releases/download/2.1.6/AppleSupport-2.1.6-RELEASE.zip
+1bc4f5e5c193762e5216dd6104bc871a853e2187f35ec170e75fe121451b8966

--- a/Installer/data/Lilu/source.txt
+++ b/Installer/data/Lilu/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/Lilu/releases/download/1.4.1/Lilu-1.4.1-RELEASE.zip
-6daf5753b1ed2df458c91f77f6bed418a6a5299cf443e4b81426037e0364b71c
+https://github.com/acidanthera/Lilu/releases/download/1.4.2/Lilu-1.4.2-RELEASE.zip
+de787dcd9d8a0eaeeb64cf86d800a9382c147a391306121f0c0fe0f91aff4561

--- a/Installer/data/MacInfo/source.txt
+++ b/Installer/data/MacInfo/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/MacInfoPkg/releases/download/2.1.0/macinfo-2.1.0-mac.zip
-413768dbea1e17f3ac5ac9509f2a886f7b234b4810e5c95c0d4f01563593f8ac
+https://github.com/acidanthera/MacInfoPkg/releases/download/2.1.1/macinfo-2.1.1-mac.zip
+0c8bc7ccf2bcf0769d5cbd85ecec630424855336f1b40dbde7a2e9b3655356ee

--- a/Installer/data/OpenCore/source.txt
+++ b/Installer/data/OpenCore/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/OpenCorePkg/releases/download/0.5.4/OpenCore-0.5.4-RELEASE.zip
-582b572074ef9fb8c608a1ee6db755d8fc8fec86543939ff164dc8851de1919e
+https://github.com/acidanthera/OpenCorePkg/releases/download/0.5.6/OpenCore-0.5.6-RELEASE.zip
+aefc2a120fa8a6265c88780c54bfb8ef68b741438f5dc27921ecb85cc800d760

--- a/Installer/data/VirtualSMC/source.txt
+++ b/Installer/data/VirtualSMC/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/VirtualSMC/releases/download/1.1.0/VirtualSMC-1.1.0-RELEASE.zip
-d7554c0ac2bd48ef188441d4552aae43320c04fabe743dd94791b15324878046
+https://github.com/acidanthera/VirtualSMC/releases/download/1.1.1/VirtualSMC-1.1.1-RELEASE.zip
+2605970331061ed4c8ff9075ceaf3a2036d83368cf555fd79ed78d5754af7f77

--- a/Installer/data/WhateverGreen/source.txt
+++ b/Installer/data/WhateverGreen/source.txt
@@ -1,2 +1,2 @@
-https://github.com/acidanthera/WhateverGreen/releases/download/1.3.6/WhateverGreen-1.3.6-RELEASE.zip
-5a9a3f6b09bd7381ab5afe3f4dc678d3a1f283e6140e3776503746033aa31d92
+https://github.com/acidanthera/WhateverGreen/releases/download/1.3.7/WhateverGreen-1.3.7-RELEASE.zip
+610872310fe748005da4c191689934794b280545ccd49f70519f1c47654750e2

--- a/Installer/scripts/postinstall.sh
+++ b/Installer/scripts/postinstall.sh
@@ -63,8 +63,7 @@ echo "Setting up unique identifiers..."
 
 if [ -f "$INSTALLER_TEMP/security" ]; then
     echo "Setting secure boot settings..."
-    $PLIST_BUDDY -c "Set :Misc:Security:RequireSignature true" "$NEW_CONFIG"
-    $PLIST_BUDDY -c "Set :Misc:Security:RequireVault true" "$NEW_CONFIG"
+    $PLIST_BUDDY -c "Set :Misc:Security:Vault Secure" "$NEW_CONFIG"
     echo "Generating secure vault..."
     ./sign.command "$EFI_ROOT_DIR/EFI/OC"
     rm -rf "$EFI_ROOT_DIR/EFI/OC/Keys" # make sure to delete the private keys

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -539,7 +539,6 @@
 			<string>ApfsDriverLoader.efi</string>
 			<string>FwRuntimeServices.efi</string>
 			<string>HFSPlus.efi</string>
-			<string>VirtualSmc.efi</string>
 		</array>
 		<key>Input</key>
 		<dict>
@@ -554,6 +553,8 @@
 		</dict>
 		<key>Protocols</key>
 		<dict>
+			<key>AppleSmcIo</key>
+			<true/>
 			<key>ConsoleControl</key>
 			<true/>
 		</dict>

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -472,8 +472,6 @@
 		<dict>
 			<key>HibernateMode</key>
 			<string>None</string>
-			<key>UsePicker</key>
-			<true/>
 		</dict>
 		<key>Security</key>
 		<dict>
@@ -483,12 +481,10 @@
 			<true/>
 			<key>AuthRestart</key>
 			<true/>
-			<key>RequireSignature</key>
-			<false/>
-			<key>RequireVault</key>
-			<false/>
 			<key>ScanPolicy</key>
 			<integer>0</integer>
+			<key>Vault</key>
+			<string>Optional</string>
 		</dict>
 	</dict>
 	<key>NVRAM</key>
@@ -551,19 +547,20 @@
 			<key>KeySupportMode</key>
 			<string>Auto</string>
 		</dict>
+		<key>Output</key>
+		<dict>
+			<key>ProvideConsoleGop</key>
+			<true/>
+			<key>Resolution</key>
+			<string>Max</string>
+		</dict>
 		<key>Protocols</key>
 		<dict>
 			<key>AppleSmcIo</key>
 			<true/>
-			<key>ConsoleControl</key>
-			<true/>
 		</dict>
 		<key>Quirks</key>
 		<dict>
-			<key>IgnoreTextInGraphics</key>
-			<true/>
-			<key>ProvideConsoleGop</key>
-			<true/>
 			<key>RequestBootVarRouting</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
This PR updates OpenCore to 0.5.6, with the corresponding config.plist changes.
Also update source.txt to the latest release if available.

This should resolve some issues with macOS 10.15.4.
https://github.com/osy86/HaC-Mini/issues/218
https://github.com/osy86/HaC-Mini/issues/219
https://github.com/osy86/HaC-Mini/issues/221

This is the generated HacMini.pkg build from my fork.
[HaCMini.pkg.zip](https://github.com/osy86/HaC-Mini/files/4390026/HaCMini.pkg.zip)
Use with caution, except for testing purpose, This PR is still WIP.

Open to feedback and suggestion. Thanks!