### PR TITLE
Brcm4360_Injector should be blocked in Big Sur

### DIFF
--- a/Installer/scripts/install_kexts.sh
+++ b/Installer/scripts/install_kexts.sh
@@ -34,6 +34,10 @@ do
     echo "PlistPath:      $info"
     $PLIST_BUDDY -c "Add :Kernel:Add:$i:PlistPath string $info" "$CONFIG"
     base=`basename $kext`
+    # Brcm4360_Injector should be blocked in Big Sur
+    if [ $base == "AirPortBrcm4360_Injector.kext" ]; then
+        $PLIST_BUDDY -c "Add :Kernel:Add:$i:MaxKernel string 19.9.9" "$CONFIG"
+    fi
     base="${base/.kext/}"
     exe=`find "$line" -name "$base" -type f -maxdepth 3 | head -1`
     exe="${exe/$line\//}"


### PR DESCRIPTION
As noted in AirPortBrcm 2.0.8 release note:
> Under 11.0 (Big Sur) plugin AirPortBrcm4360_Injector.kext must be blocked by MaxKernel 19.9.9 or just removed, otherwise it will block loading of AirPortBrcmNIC since class AirPortBrcm4360 is unsupported.

This should fix the wifi issue in https://github.com/osy86/HaC-Mini/issues/318
`What's worse is that my WIFI of DW1820A cannot be used under big sur, and the startup and shutdown time is very long.`