### PR TITLE
installer: enable Secure Boot "Full Security"

### DIFF
--- a/Installer/Package.pkgproj
+++ b/Installer/Package.pkgproj
@@ -11497,7 +11497,7 @@
 												<key>LANGUAGE</key>
 												<string>English</string>
 												<key>VALUE</key>
-												<string>Sets up OC signed vault features. If enabled, you must re-generate and re-sign the vault after making any modifications.</string>
+												<string>Sets up OC signed vault features. If enabled, you must re-generate and re-sign the vault after making any modifications. You may also have to re-install macOS from recovery.</string>
 											</dict>
 											<dict>
 												<key>LANGUAGE</key>

--- a/Installer/scripts/postinstall.sh
+++ b/Installer/scripts/postinstall.sh
@@ -69,6 +69,7 @@ echo "Setting up unique identifiers..."
 if [ -f "$INSTALLER_TEMP/security" ]; then
     echo "Setting secure boot settings..."
     $PLIST_BUDDY -c "Set :Misc:Security:Vault Secure" "$NEW_CONFIG"
+    $PLIST_BUDDY -c "Set :Misc:Security:SecureBootModel j174" "$NEW_CONFIG"
     echo "Generating secure vault..."
     ./sign.command "$EFI_ROOT_DIR/EFI/OC"
     rm -rf "$EFI_ROOT_DIR/EFI/OC/Keys" # make sure to delete the private keys

--- a/OC/config.plist
+++ b/OC/config.plist
@@ -495,6 +495,8 @@
 			<true/>
 			<key>AllowSetDefault</key>
 			<true/>
+			<key>ApECID</key>
+			<integer>0</integer>
 			<key>AuthRestart</key>
 			<true/>
 			<key>BootProtect</key>


### PR DESCRIPTION
Implement ECID generation and updated "secure boot" option to use new OC
feature to support "Full Security"

Closes #328 